### PR TITLE
feat: allow configuring API base URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,16 @@ https://ntut-course.gnehs.net/doc
 ## 爬蟲與資料
 https://github.com/gnehs/ntut-course-crawler-node
 
+## 環境變數
+
+可透過 `base_url` 環境變數指定 API 進入點，
+未設定時預設為 `https://gnehs.github.io/ntut-course-crawler-node/`。
+
+```bash
+# 使用自訂的 API 進入點啟動開發伺服器
+base_url=https://example.com npm run dev
+```
+
 ## Build Setup
 
 ```bash

--- a/generateCoursePreview.mjs
+++ b/generateCoursePreview.mjs
@@ -1,6 +1,7 @@
 import axios from "axios";
 import fs from "fs";
 import { JSDOM } from "jsdom";
+import { apiUrl } from "./utils/api.js";
 
 
 
@@ -33,8 +34,8 @@ function updateTags({ title, description, image, url }) {
   document.querySelector('title').textContent = title
 }
 console.log('Generate course preview')
-let yearSems = await axios.get('https://gnehs.github.io/ntut-course-crawler-node/main.json').then((res) => res.data);
-let withdrawal = await axios.get(`https://gnehs.github.io/ntut-course-crawler-node/analytics/withdrawal.json`).then((res) => res.data);
+let yearSems = await axios.get(apiUrl('/main.json')).then((res) => res.data);
+let withdrawal = await axios.get(apiUrl('/analytics/withdrawal.json')).then((res) => res.data);
 console.log(`Data fetched`)
 
 let tasks = []
@@ -42,8 +43,8 @@ tasks.push(...Object.entries(yearSems)
   .map((([year, sems]) => sems.map(sem => ({ year, sem }))))
   .flat()
   .map(async ({ year, sem }) => {
-    let courses = await axios.get(`https://gnehs.github.io/ntut-course-crawler-node/${year}/${sem}/main.json`).then(x => x.data)
-    let departments = await axios.get(`https://gnehs.github.io/ntut-course-crawler-node/${year}/${sem}/department.json`).then(x => x.data)
+    let courses = await axios.get(apiUrl(`/${year}/${sem}/main.json`)).then(x => x.data)
+    let departments = await axios.get(apiUrl(`/${year}/${sem}/department.json`)).then(x => x.data)
     fs.mkdirSync(`./dist/course/${year}/${sem}/`, { recursive: true })
     fs.mkdirSync(`./dist/class/${year}/${sem}/`, { recursive: true })
 

--- a/layouts/default.vue
+++ b/layouts/default.vue
@@ -243,7 +243,7 @@ export default {
             text: "下載課程清單...",
           });
           result = await fetch(
-            `https://gnehs.github.io/ntut-course-crawler-node/${y}/${s}/${department}.json`
+            this.$api(`/${y}/${s}/${department}.json`)
           ).then((x) => x.json());
           await this.$setStore(dataKey, result);
           loading.close();
@@ -271,7 +271,7 @@ export default {
       let key = `main_year`;
       try {
         let res = await fetch(
-          `https://gnehs.github.io/ntut-course-crawler-node/main.json`
+          this.$api('/main.json')
         ).then((x) => x.json());
         sessionStorage[key] = JSON.stringify(res);
         return JSON.parse(sessionStorage[key]);
@@ -348,7 +348,7 @@ export default {
       let res = await this.$getStore("withdrawalRate");
       if (!res) {
         res = await fetch(
-          `https://gnehs.github.io/ntut-course-crawler-node/analytics/withdrawal-rate.json`
+          this.$api('/analytics/withdrawal-rate.json')
         ).then((x) => x.json());
         await this.$setStore("withdrawalRate", res, 30);
       }

--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -31,6 +31,7 @@ export default {
 
   // Plugins to run before rendering page (https://go.nuxtjs.dev/config-plugins)
   plugins: [
+    '@/plugins/api',
     '@/plugins/ics',
     '@/plugins/vuesax',
     '@/plugins/vlf',

--- a/pages/add-calendar.vue
+++ b/pages/add-calendar.vue
@@ -131,7 +131,7 @@ export default {
   },
   methods: {
     async getCalendar() {
-      let calendarData = await fetch(`https://gnehs.github.io/ntut-course-crawler-node/calendar.json`).then(x => x.json())
+      let calendarData = await fetch(this.$api('/calendar.json')).then(x => x.json())
       let startDays = calendarData.filter(x => x.summary.includes('開學')).map(x => x.start)
       let endDays = calendarData.filter(x => x.summary == '期末考試').map(x => x.end)
 

--- a/pages/advanced-search.vue
+++ b/pages/advanced-search.vue
@@ -230,7 +230,7 @@ export default {
   methods: {
     async getWithdrawalRate() {
       if (!this.withdrawalRate) {
-        let res = await fetch(`https://gnehs.github.io/ntut-course-crawler-node/analytics/withdrawal-rate.json`)
+        let res = await fetch(this.$api('/analytics/withdrawal-rate.json'))
           .then(x => x.json())
         this.withdrawalRate = res
       }
@@ -242,7 +242,7 @@ export default {
     async fetchDepartmentData() {
       if (!this.departmentData) {
         let { year, sem } = this.$route.query
-        let res = await fetch(`https://gnehs.github.io/ntut-course-crawler-node/${year}/${sem}/department.json`)
+        let res = await fetch(this.$api(`/${year}/${sem}/department.json`))
           .then(x => x.json())
         this.departmentData = res
         // update academyList

--- a/pages/calendar.vue
+++ b/pages/calendar.vue
@@ -59,7 +59,7 @@ export default {
   },
   methods: {
     getCalendarData() {
-      fetch(`https://gnehs.github.io/ntut-course-crawler-node/calendar.json`)
+      fetch(this.$api('/calendar.json'))
         .then(response => response.json())
         .then(response => {
           this.calendarData = response

--- a/pages/class/_year/_sem/_id.vue
+++ b/pages/class/_year/_sem/_id.vue
@@ -70,7 +70,7 @@ export default {
         let { year, sem } = this.$route.params
         this.classname = this.$route.params.id
         //fetch class
-        let departmentData = await fetch(`https://gnehs.github.io/ntut-course-crawler-node/${year}/${sem}/department.json`)
+        let departmentData = await fetch(this.$api(`/${year}/${sem}/department.json`))
         .then(x =>x.json())
         departmentData.map(x => {
           x.class.map(y => {

--- a/pages/class/index.vue
+++ b/pages/class/index.vue
@@ -80,7 +80,7 @@ export default {
       const loading = this.$vs.loading()
       try {
         this.departmentData = await fetch(
-          `https://gnehs.github.io/ntut-course-crawler-node/${this.year}/${this.sem}/department.json`
+          this.$api(`/${this.year}/${this.sem}/department.json`)
         ).then(x => x.json())
         this.filteredDepartmentData = this.departmentData
         loading.close()

--- a/pages/course/_year/_sem/_id.vue
+++ b/pages/course/_year/_sem/_id.vue
@@ -440,7 +440,7 @@ export default {
         this.checkCourseInMyCourse();
         this.checkIsCourseConflict();
         this.fetchedCourseData = await fetch(
-          `https://gnehs.github.io/ntut-course-crawler-node/${year}/${sem}/course/${courseId}.json`
+          this.$api(`/${year}/${sem}/course/${courseId}.json`)
         ).then((x) => x.json());
         if (this.fetchedCourseData.length > 1) {
           this.chooseClassSelect = true;

--- a/pages/standard.vue
+++ b/pages/standard.vue
@@ -174,7 +174,7 @@ export default {
         this.years = null
         let res = await this.$getStore('standards')
         if (!res) {
-          res = await fetch(`https://gnehs.github.io/ntut-course-crawler-node/standards.json`).then(x => x.json())
+          res = await fetch(this.$api('/standards.json')).then(x => x.json())
         }
         this.years = structuredClone(res)
         await this.$setStore('standards', res, 30)
@@ -187,7 +187,7 @@ export default {
       try {
         let res = await this.$getStore(`standard_${yr}`)
         if (!res) {
-          res = await fetch(`https://gnehs.github.io/ntut-course-crawler-node/${yr}/standard.json`).then(x => x.json())
+          res = await fetch(this.$api(`/${yr}/standard.json`)).then(x => x.json())
         }
         this.standardData = structuredClone(res)
         await this.$setStore(`standard_${yr}`, res, 30)

--- a/pages/teacher/_id.vue
+++ b/pages/teacher/_id.vue
@@ -131,16 +131,16 @@ export default {
   methods: {
     async getTeacher() {
       let withdrawalRateData = await fetch(
-        `https://gnehs.github.io/ntut-course-crawler-node/analytics/withdrawal-rate.json`
+        this.$api('/analytics/withdrawal-rate.json')
       ).then((res) => res.json());
       let withdrawalRateData_3y = await fetch(
-        `https://gnehs.github.io/ntut-course-crawler-node/analytics/withdrawal-rate-recent-3-years.json`
+        this.$api('/analytics/withdrawal-rate-recent-3-years.json')
       ).then((res) => res.json());
       let withdrawalRateData_5y = await fetch(
-        `https://gnehs.github.io/ntut-course-crawler-node/analytics/withdrawal-rate-recent-5-years.json`
+        this.$api('/analytics/withdrawal-rate-recent-5-years.json')
       ).then((res) => res.json());
       let withdrawalData = await fetch(
-        `https://gnehs.github.io/ntut-course-crawler-node/analytics/withdrawal.json`
+        this.$api('/analytics/withdrawal.json')
       ).then((res) => res.json());
       if (!withdrawalRateData[this.name]) {
         this.onError = "找不到教師";

--- a/pages/withdrawal.vue
+++ b/pages/withdrawal.vue
@@ -63,7 +63,7 @@ export default {
       let period = this.period == 'all' ? '' : this.period
       this.stat = null
       this.data = null
-      let withdrawalData = await fetch(`https://gnehs.github.io/ntut-course-crawler-node/analytics/withdrawal${period}.json`)
+      let withdrawalData = await fetch(this.$api(`/analytics/withdrawal${period}.json`))
         .then(res => res.json())
       this.stat = withdrawalData.stat
       this.data = withdrawalData.data

--- a/plugins/api.js
+++ b/plugins/api.js
@@ -1,0 +1,6 @@
+import { apiBase, apiUrl } from '@/utils/api'
+
+export default (_ctx, inject) => {
+  inject('apiBase', apiBase)
+  inject('api', apiUrl)
+}

--- a/utils/api.js
+++ b/utils/api.js
@@ -1,0 +1,2 @@
+export const apiBase = process.env.base_url || 'https://gnehs.github.io/ntut-course-crawler-node'
+export const apiUrl = (path) => `${apiBase.endsWith('/') ? apiBase.slice(0, -1) : apiBase}${path}`


### PR DESCRIPTION
## Summary
- make API base URL configurable via `base_url` env var
- centralize API URL building and inject helper
- replace hard-coded crawler URLs with helper

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: nuxt: not found)*
- `npm install` *(fails: cannot build fibers)*

------
https://chatgpt.com/codex/tasks/task_e_68c08288afc88331b4116e2f0134c48d