### PR TITLE
refactor: use API base URL in mprogram

### DIFF
--- a/pages/mprogram/_year/_sem/_id.vue
+++ b/pages/mprogram/_year/_sem/_id.vue
@@ -68,7 +68,9 @@ export default {
         let { year, sem } = this.$route.params
         this.programname = this.$route.params.id
         // fetch program list
-        let programList = await fetch(`https://gnehs.github.io/ntut-course-crawler-node/${year}/${sem}/mprogram.json`).then(x => x.json())
+        let programList = await fetch(
+          this.$api(`/${year}/${sem}/mprogram.json`)
+        ).then(x => x.json())
         programList.map(x => {
           x.class.map(y => {
             if (y.name == this.programname) {

--- a/pages/mprogram/index.vue
+++ b/pages/mprogram/index.vue
@@ -65,7 +65,7 @@ export default {
       const loading = this.$vs.loading()
       try {
         this.programData = await fetch(
-          `https://gnehs.github.io/ntut-course-crawler-node/${this.year}/${this.sem}/mprogram.json`
+          this.$api(`/${this.year}/${this.sem}/mprogram.json`)
         ).then(x => x.json())
         this.filteredProgramData = this.programData
       } catch (e) {


### PR DESCRIPTION
## Summary
- replace hardcoded mprogram URLs with `$api` helper

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c48b1604988331a5d75c845c44ed32