### PR TITLE
fix: normalize API path

### DIFF
--- a/utils/api.js
+++ b/utils/api.js
@@ -1,6 +1,10 @@
 const apiBase = process.env.BASE_URL || 'https://gnehs.github.io/ntut-course-crawler-node'
 
-const apiUrl = (path) => `${apiBase.endsWith('/') ? apiBase.slice(0, -1) : apiBase}${path}`
+const apiUrl = (path) => {
+  const base = apiBase.endsWith('/') ? apiBase.slice(0, -1) : apiBase
+  const normalizedPath = path.startsWith('/') ? path : `/${path}`
+  return `${base}${normalizedPath}`
+}
 
 module.exports = {
   apiBase,


### PR DESCRIPTION
## Summary
- ensure `apiUrl` prepends a leading slash when needed

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c48f0647d8833199f074a97c497a1c