### PR TITLE
Expose API base via runtime config

### DIFF
--- a/nuxt.config.js
+++ b/nuxt.config.js
@@ -60,6 +60,10 @@ export default {
     '@nuxtjs/google-adsense'
   ],
 
+  publicRuntimeConfig: {
+    apiBase: process.env.BASE_URL || 'https://gnehs.github.io/ntut-course-crawler-node'
+  },
+
   // Build Configuration (https://go.nuxtjs.dev/config-build)
   build: {
   },

--- a/plugins/api.js
+++ b/plugins/api.js
@@ -1,7 +1,7 @@
-import api from '@/utils/api'
+import createApi from '@/utils/api'
 
-export default (_ctx, inject) => {
-  const { apiBase, apiUrl } = api
+export default (context, inject) => {
+  const { apiBase, apiUrl } = createApi(context.$config.apiBase)
 
   inject('apiBase', apiBase)
   inject('api', apiUrl)

--- a/utils/api.js
+++ b/utils/api.js
@@ -1,12 +1,8 @@
-const apiBase = process.env.BASE_URL || 'https://gnehs.github.io/ntut-course-crawler-node'
-
-const apiUrl = (path) => {
-  const base = apiBase.endsWith('/') ? apiBase.slice(0, -1) : apiBase
-  const normalizedPath = path.startsWith('/') ? path : `/${path}`
-  return `${base}${normalizedPath}`
-}
-
-module.exports = {
-  apiBase,
-  apiUrl
+export default function createApi(apiBase) {
+  const apiUrl = (path) => {
+    const base = apiBase.endsWith('/') ? apiBase.slice(0, -1) : apiBase
+    const normalizedPath = path.startsWith('/') ? path : `/${path}`
+    return `${base}${normalizedPath}`
+  }
+  return { apiBase, apiUrl }
 }


### PR DESCRIPTION
## Summary
- expose API base URL through `publicRuntimeConfig`
- generate API helper using runtime-configured base
- use runtime config in API plugin

## Testing
- `npm install` *(fails: fibers build failed for node-gyp, nuxt missing)*
- `npm run build` *(fails: nuxt not found due to install failure)*
- `node -e "import createApi from './utils/api.js'; const {apiUrl}=createApi('https://api.example'); console.log(apiUrl('/ping'));"`


------
https://chatgpt.com/codex/tasks/task_e_68c4920c3ba08331936c77de1994d544