### PR TITLE
refactor: expose api helper via CommonJS

### DIFF
--- a/generateCoursePreview.mjs
+++ b/generateCoursePreview.mjs
@@ -1,8 +1,8 @@
 import axios from "axios";
 import fs from "fs";
 import { JSDOM } from "jsdom";
-import api from "./utils/api.js";
-const { apiUrl } = api;
+import createApi from "./utils/api.js";
+const { apiUrl } = createApi(process.env.BASE_URL || 'https://gnehs.github.io/ntut-course-crawler-node');
 
 
 let now = new Date()

--- a/utils/api.js
+++ b/utils/api.js
@@ -1,4 +1,4 @@
-export default function createApi(apiBase) {
+function createApi(apiBase) {
   const apiUrl = (path) => {
     const base = apiBase.endsWith('/') ? apiBase.slice(0, -1) : apiBase
     const normalizedPath = path.startsWith('/') ? path : `/${path}`
@@ -6,3 +6,6 @@ export default function createApi(apiBase) {
   }
   return { apiBase, apiUrl }
 }
+
+module.exports = createApi
+module.exports.default = createApi


### PR DESCRIPTION
## Summary
- refactor utils/api.js to expose createApi via module.exports
- update generateCoursePreview.mjs to instantiate API helper with configurable base URL

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c494e4454883319a9e1c605929f90d